### PR TITLE
add coonfiguration ssr (minor)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to `@todovue/tv-button` will be documented in this file.
 This project adheres to [Semantic Versioning](https://semver.org/).
 
 ---
+## [1.1.1] - 2025-08-29
+### Changed
+- The library build now uses `src/entry.ts` (exports both the component and the plugin) instead of directly exporting the `.vue` file.
+- CSS injection via JS has been removed for the library build (it is only kept for the demo), generating a `tv-button.css` file optimized for SSR/Nuxt.
+
+### Added
+- Plugin installation support: `app.use(TvButton)` or `app.use(TvButtonPlugin)`.
+- Explicit export of the style file: `import '@todovue/tv-button/style.css'`.
+- Documentation for usage in SSR and Nuxt 3 applications.
+
+### Internals
+- `package.json` exposes `style`, `sideEffects`, and the export of `./style.css` for safe tree-shaking.
+
 ## [1.1.0] - 2025-05-08
 ### ✨ Added
 - Add icon-only button support with styling and documentation updates
@@ -38,5 +51,6 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 
 ---
+[1.1.1]: https://github.com/TODOvue/tv-button/pull/14/files
 [1.1.0]: https://github.com/TODOvue/tv-button/pull/13/files
 [1.0.0]: https://github.com/TODOvue/tv-button/pull/12/files

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,17 +5,17 @@ All notable changes to `@todovue/tv-button` will be documented in this file.
 This project adheres to [Semantic Versioning](https://semver.org/).
 
 ---
-## [1.1.1] - 2025-08-29
-### Changed
+## [1.1.1] - 2025-09-05
+### 🔧 Changed
 - The library build now uses `src/entry.ts` (exports both the component and the plugin) instead of directly exporting the `.vue` file.
 - CSS injection via JS has been removed for the library build (it is only kept for the demo), generating a `tv-button.css` file optimized for SSR/Nuxt.
 
-### Added
+### ✨ Added
 - Plugin installation support: `app.use(TvButton)` or `app.use(TvButtonPlugin)`.
 - Explicit export of the style file: `import '@todovue/tv-button/style.css'`.
 - Documentation for usage in SSR and Nuxt 3 applications.
 
-### Internals
+### 📦 Improved
 - `package.json` exposes `style`, `sideEffects`, and the export of `./style.css` for safe tree-shaking.
 
 ## [1.1.0] - 2025-05-08

--- a/README.md
+++ b/README.md
@@ -1,191 +1,250 @@
 <p align="center"><img width="150" src="https://firebasestorage.googleapis.com/v0/b/todovue-blog.appspot.com/o/logo.png?alt=media&token=d8eb592f-e4a9-4b02-8aff-62d337745f41" alt="TODOvue logo">
 </p>
 
-# TODOvue Button
-###### TvButton is a custom button component for web applications.
+# TODOvue Button (TvButton)
+A flexible, framework‑agnostic Vue 3 button component with variants, sizes, icons, loading state, and customization utilities. Ship it in Single Page Apps or Server-Side Rendered (SSR) environments (e.g. Nuxt 3) with zero DOM assumptions.
 
-[![npm](https://img.shields.io/npm/v/@todovue/tv-button.svg)](https://www.npmjs.com/package/@todovue/tv-button) [![Netlify Status](https://api.netlify.com/api/v1/badges/3c413109-63aa-41d7-8126-a527435f5512/deploy-status)](https://app.netlify.com/sites/tv-button/deploys) [![npm](https://img.shields.io/npm/dm/@todovue/tv-button.svg)](https://www.npmjs.com/package/@todovue/tv-button)
-[![npm](https://img.shields.io/npm/d18m/@todovue/tv-button.svg)](https://www.npmjs.com/package/@todovue/tv-button) ![GitHub](https://img.shields.io/github/license/TODOvue/tv-button) ![GitHub Release Date](https://img.shields.io/github/release-date/TODOvue/tv-button)
+[![npm](https://img.shields.io/npm/v/@todovue/tv-button.svg)](https://www.npmjs.com/package/@todovue/tv-button)
+[![npm downloads](https://img.shields.io/npm/dm/@todovue/tv-button.svg)](https://www.npmjs.com/package/@todovue/tv-button)
+![License](https://img.shields.io/github/license/TODOvue/tv-button)
 
+> Demo: https://tv-button.netlify.app/
+
+---
 ## Table of Contents
-- [Demo](https://tv-button.netlify.app/)
+- [Features](#features)
 - [Installation](#installation)
-- [Usage](#usage)
+- [Quick Start (SPA)](#quick-start-spa)
+- [Nuxt 3 / SSR Usage](#nuxt-3--ssr-usage)
+- [Component Registration Options](#component-registration-options)
 - [Props](#props)
 - [Events](#events)
-- [Customize](#customize)
+- [Icons](#icons)
+- [Customization (Styles / Theming)](#customization-styles--theming)
+- [Icon-only & Variant Notes](#icon-only--variant-notes)
+- [Accessibility](#accessibility)
+- [SSR Notes](#ssr-notes)
+- [Roadmap](#roadmap)
 - [Development](#development)
-- [Changelog](https://github.com/TODOvue/tv-button/blob/main/CHANGELOG.md)
-- [Contributing](https://github.com/TODOvue/tv-button/blob/main/CONTRIBUTING.md)
-- [License](https://github.com/TODOvue/tv-button/blob/main/LICENSE)
+- [Contributing](#contributing)
+- [License](#license)
 
+---
+## Features
+- Multiple visual states: success, info, warning, error, text, outlined
+- Sizes: small, default, large, full-width option
+- Icon support (pre-bundled SVG set via `import.meta.glob`)
+- Icon-only and pure icon modes (`type="icon"` + `iconOnly`)
+- Loading state with spinner
+- Custom inline style override via `customStyle`
+- Emits both a custom event and the native click
+- Works in SPA and SSR (Nuxt 3) contexts
+- Tree-shake friendly (Vue marked external in library build)
+
+---
 ## Installation
-Install with npm or yarn
+Using npm:
 ```bash
 npm install @todovue/tv-button
 ```
+Using yarn:
 ```bash
 yarn add @todovue/tv-button
 ```
-
-Import the component:
-```js
-import TvButton from "@todovue/tv-button";
+Using pnpm:
+```bash
+pnpm add @todovue/tv-button
 ```
 
-You can also register it globally in **main.js**:
+Import the CSS (required to get styles):
 ```js
-import { createApp } from "vue";
-import App from "./App.vue";
-import TvButton from "@todovue/tv-button";
-
-const app = createApp(App);
-app.component("TvButton", TvButton);
-app.mount("#app");
+import '@todovue/tv-button/style.css'
 ```
 
 ---
+## Quick Start (SPA)
+Global registration (main.js / main.ts):
+```js
+import { createApp } from 'vue'
+import App from './App.vue'
+import TvButton from '@todovue/tv-button'
+import '@todovue/tv-button/style.css'
 
-## Usage
-```html
+createApp(App)
+  .use(TvButton) // enables <TvButton /> globally
+  .mount('#app')
+```
+Local import inside a component:
+```vue
 <script setup>
-import TvButton from "@todovue/tv-button"; // Only if not imported in main.js
-    
-const handleClick = () => {
-  console.log("Clicked!");
-};
+import { TvButton } from '@todovue/tv-button'
+import '@todovue/tv-button/style.css'
+
+function onSubmit() {
+  console.log('Clicked')
+}
 </script>
 
 <template>
-  <tv-button @click-button="handleClick">
-    Click me
-  </tv-button>
+  <TvButton success icon="check" @click-button="onSubmit">Submit</TvButton>
 </template>
 ```
 
 ---
+## Nuxt 3 / SSR Usage
+Create a plugin file: `plugins/tv-button.client.ts` (client-only is fine, or without suffix for SSR as it is safe):
+```ts
+import { defineNuxtPlugin } from '#app'
+import TvButton from '@todovue/tv-button'
+import '@todovue/tv-button/style.css'
 
+export default defineNuxtPlugin(nuxtApp => {
+  nuxtApp.vueApp.use(TvButton)
+})
+```
+Use anywhere:
+```vue
+<TvButton outlined icon="info">Details</TvButton>
+```
+Optional direct import (no plugin):
+```vue
+<script setup>
+import { TvButton } from '@todovue/tv-button'
+import '@todovue/tv-button/style.css'
+</script>
+```
+
+---
+## Component Registration Options
+| Approach | When to use |
+|----------|-------------|
+| Global via `app.use(TvButton)` | Many usages across app / design system install |
+| Local named import `{ TvButton }` | Isolated / code-split contexts |
+| Direct default import `import TvButton from '@todovue/tv-button'` | Single usage or manual registration |
+
+---
 ## Props
-| Name                       | Type    | Default  | Description                                                                        |
-|----------------------------|---------|----------|------------------------------------------------------------------------------------|
-| type                       | String  | `button` | Defines the button type: `"button"` or `"icon"` (icon-only button).                |
-| customStyle                | Object  | `{}`     | Custom styles for the button (e.g., `{ backgroundColor: "#000", color: "#fff" }`). |
-| `isOutlined` or `outlined` | Boolean | `false`  | If `true`, the button will be outlined instead of filled.                          |
-| `isSmall` or `small`       | Boolean | `false`  | If `true`, the button will be small.                                               |
-| `isLarge` or `large`       | Boolean | `false`  | If `true`, the button will be large.                                               |
-| `isSuccess` or `success`   | Boolean | `false`  | If `true`, the button will be styled as a success button.                          |
-| `isInfo` or `info`         | Boolean | `false`  | If `true`, the button will be styled as an info button.                            |
-| `isWarning` or `warning`   | Boolean | `false`  | If `true`, the button will be styled as a warning button.                          |
-| `isError` or `error`       | Boolean | `false`  | If `true`, the button will be styled as an error button.                           |
-| `isDisabled` or `disabled` | Boolean | `false`  | If `true`, the button will be disabled.                                            |
-| `isText` or `text`         | Boolean | `false`  | If `true`, the button will be styled as a text button.                             |
-| icon                       | String  | `null`   | The name of the icon to be displayed inside the button.                            |
-| iconOnly                   | Boolean | `false`  | If `true`, shows only the icon without background or padding (pure icon button).   |
-| iconPosition               | String  | `right`  | The position of the icon (`left` or `right`).                                      |
-| buttonText                 | String  | `''`     | The text inside the button (alternative to using `slot`).                          |
-| ariaLabel                  | String  | `''`     | The aria-label attribute for the button.                                           |
-| `isLoading` or `loading`   | Boolean | `false`  | If `true`, replaces content with a spinner and disables the button.                |
+All boolean style props have two interchangeable forms: a long form (`isSomething`) and a short alias.
+
+| Prop | Aliases | Type | Default | Description |
+|------|---------|------|---------|-------------|
+| buttonText | — | string | '' | Optional text (alternative to slot). |
+| customStyle | — | object | {} | Inline style overrides (`{ backgroundColor, color }`). |
+| icon | — | string | null | Name of bundled icon. |
+| iconColor | — | string | 'white' | Declared but currently not applied (see Roadmap). |
+| iconPosition | — | 'left' \| 'right' | 'right' | Icon position relative to text. |
+| type | — | 'button' \| 'icon' | 'button' | Variant selector AND passed to native `type` attribute (see note below). |
+| ariaLabel | — | string | '' | Accessibility label (required if no text / icon-only). |
+| iconOnly | — | boolean | false | Renders only the icon (no padding/background). |
+| isOutlined | outlined | boolean | false | Outlined style. |
+| isSmall | small | boolean | false | Small size. |
+| isLarge | large | boolean | false | Large size. |
+| isSuccess | success | boolean | false | Success variant. |
+| isInfo | info | boolean | false | Info variant. |
+| isWarning | warning | boolean | false | Warning variant. |
+| isError | error | boolean | false | Error variant. |
+| isDisabled | disabled | boolean | false | Disables interaction. |
+| isText | text | boolean | false | Text (minimal) style. |
+| isFull | full | boolean | false | Full width. |
+| isRounded | rounded | boolean | false | Rounded corners. |
+| isLoading | loading | boolean | false | Shows spinner & disables. |
+| isCircle | circle | boolean | false | Currently unused (placeholder). |
+
+> Note: Because `type` is bound to the native `<button type="...">`, using `type="icon"` produces a non-standard button attribute. This does not break rendering but is semantically incorrect in forms. A future release will introduce `variant` and keep `htmlType` separate (see Roadmap).
 
 ---
-
-### 🔹 **Icons**
-You can use the following icons (`icon="account"`):
-- `account`
-- `add-user`
-- `alert`
-- `arrow-down`
-- `arrow-left`
-- `arrow-right`
-- `arrow-up`
-- `block`
-- `calendar`
-- `cancel`
-- `check`
-- `clone`
-- `dark`
-- `download`
-- `edit`
-- `external-link`
-- `favorite`
-- `filter`
-- `help`
-- `info`
-- `light`
-- `lock`
-- `login`
-- `logout`
-- `menu`
-- `minus`
-- `notification`
-- `plus`
-- `remove`
-- `search`
-- `settings`
-- `share`
-- `star`
-- `todovue`
-- `unlock`
-- `update`
-- `view`
-
----
-
 ## Events
-| Name         | Description                                                                 |
-|--------------|-----------------------------------------------------------------------------|
-| click-button | Emitted when the button is clicked. You can use it to call a function, etc. |
-| click        | Emitted when the button is clicked. You can use it to call a function, etc. |
+| Event name (kebab) | Emits (camel) | Description |
+|--------------------|---------------|-------------|
+| `click-button` | `clickButton` | Custom semantic click event. |
+| `click` | `click` | Native passthrough (also emitted manually). |
 
----
-
-## Customize
-You can customize the button style using `customStyle`. You can include `backgroundColor` and `color`.
-
-```html
-<script setup>
-import TvButton from "@todovue/tv-button";
-
-const customStyle = {
-  backgroundColor: "#0f2e5b",
-  color: "#fff",
-};
-</script>
-
-<template>
-  <tv-button :customStyle="customStyle">
-    Custom Button
-  </tv-button>
-</template>
+Usage:
+```vue
+<TvButton @click-button="onAction" />
+<TvButton @click="onNative" />
 ```
 
 ---
+## Icons
+Set with the `icon` prop. Available names:
+`account`, `add-user`, `alert`, `arrow-down`, `arrow-left`, `arrow-right`, `arrow-up`, `block`, `calendar`, `cancel`, `check`, `clone`, `dark`, `download`, `edit`, `external-link`, `favorite`, `filter`, `help`, `info`, `light`, `loading`, `lock`, `login`, `logout`, `menu`, `minus`, `notification`, `plus`, `remove`, `search`, `settings`, `share`, `star`, `todovue`, `unlock`, `update`, `view`.
 
-## 🔥 **Icon-Only Button (`type="icon"`)**
-If you want a button with only an icon, use `type="icon"`. The button will automatically adjust its size.
-
-```html
-<tv-button icon="trash" type="icon" />
-<tv-button icon="check" type="icon"/>
-<tv-button icon="info" type="icon" />
+Example:
+```vue
+<TvButton icon="check" success>Saved</TvButton>
+<TvButton icon="info" iconPosition="left" outlined>Info</TvButton>
 ```
-
-If you want to display just the SVG icon with no background, border, or padding at all (like an inline action icon), use the `iconOnly` prop:
-
-```html
-<tv-button icon="edit" type="icon" :iconOnly="true" />
-```
-
-This is useful for icon buttons that behave like plain clickable icons.
 
 ---
+## Customization (Styles / Theming)
+Inline overrides via `customStyle`:
+```vue
+<TvButton :customStyle="{ backgroundColor: '#0f2e5b', color: '#fff' }">Branded</TvButton>
+```
+Outlined variant adapts automatically:
+```vue
+<TvButton outlined :customStyle="{ backgroundColor: '#ff4081', color: '#fff' }">Pink Outline</TvButton>
+```
+> A subtle hover darkening is auto-generated when `customStyle.backgroundColor` exists.
 
+---
+## Icon-only & Variant Notes
+Pure icon button:
+```vue
+<TvButton type="icon" icon="edit" />
+```
+Inline icon-only action (no background / padding):
+```vue
+<TvButton type="icon" icon="edit" :iconOnly="true" aria-label="Edit item" />
+```
+Loading state:
+```vue
+<TvButton loading icon="download">Processing...</TvButton>
+```
+
+---
+## Accessibility
+- Always provide visible text OR `aria-label`.
+- Mandatory: add `aria-label` when using `iconOnly` or when slot content is empty.
+- Disabled state uses both `disabled` attribute and styling classes.
+
+---
+## SSR Notes
+- No direct DOM (`window` / `document`) access in source → safe for SSR.
+- Styles emitted as a separate CSS file (`style.css`) in library build → ideal for Nuxt 3.
+- SVG icons are bundled via Vite's `import.meta.glob` (works in Vite + Nuxt).
+- Ensure you import `@todovue/tv-button/style.css` in an SSR-compatible entry (plugin or layout).
+
+---
+## Roadmap
+| Item | Status |
+|------|--------|
+| Separate `type` into `variant` + `htmlType` | Planned |
+| Implement `iconColor` application | Planned |
+| Implement `isCircle` styling | Planned |
+| Add theming API (CSS vars) | Considering |
+| Add ARIA improvements for loading state | Considering |
+
+---
 ## Development
-Clone the repository and install the dependencies:
 ```bash
 git clone https://github.com/TODOvue/tv-button.git
 cd tv-button
 yarn install
+yarn dev     # run demo playground
+yarn build   # build library
 ```
+Local demo served from Vite using `index.html` + `src/demo` examples.
+
+---
+## Contributing
+PRs and issues welcome. See [CONTRIBUTING.md](./CONTRIBUTING.md) and [CODE_OF_CONDUCT.md](./CODE_OF_CONDUCT.md).
+
 ---
 ## License
-[MIT](https://github.com/TODOvue/tv-button/blob/main/LICENSE)
+MIT © TODOvue
+
+---
+### Attributions
+Crafted for the TODOvue component ecosystem

--- a/README.md
+++ b/README.md
@@ -56,11 +56,6 @@ Using pnpm:
 pnpm add @todovue/tv-button
 ```
 
-Import the CSS (required to get styles):
-```js
-import '@todovue/tv-button/style.css'
-```
-
 ---
 ## Quick Start (SPA)
 Global registration (main.js / main.ts):
@@ -68,7 +63,6 @@ Global registration (main.js / main.ts):
 import { createApp } from 'vue'
 import App from './App.vue'
 import TvButton from '@todovue/tv-button'
-import '@todovue/tv-button/style.css'
 
 createApp(App)
   .use(TvButton) // enables <TvButton /> globally
@@ -78,7 +72,6 @@ Local import inside a component:
 ```vue
 <script setup>
 import { TvButton } from '@todovue/tv-button'
-import '@todovue/tv-button/style.css'
 
 function onSubmit() {
   console.log('Clicked')
@@ -96,7 +89,6 @@ Create a plugin file: `plugins/tv-button.client.ts` (client-only is fine, or wit
 ```ts
 import { defineNuxtPlugin } from '#app'
 import TvButton from '@todovue/tv-button'
-import '@todovue/tv-button/style.css'
 
 export default defineNuxtPlugin(nuxtApp => {
   nuxtApp.vueApp.use(TvButton)
@@ -110,54 +102,53 @@ Optional direct import (no plugin):
 ```vue
 <script setup>
 import { TvButton } from '@todovue/tv-button'
-import '@todovue/tv-button/style.css'
 </script>
 ```
 
 ---
 ## Component Registration Options
-| Approach | When to use |
-|----------|-------------|
-| Global via `app.use(TvButton)` | Many usages across app / design system install |
-| Local named import `{ TvButton }` | Isolated / code-split contexts |
-| Direct default import `import TvButton from '@todovue/tv-button'` | Single usage or manual registration |
+| Approach                                                          | When to use                                    |
+|-------------------------------------------------------------------|------------------------------------------------|
+| Global via `app.use(TvButton)`                                    | Many usages across app / design system install |
+| Local named import `{ TvButton }`                                 | Isolated / code-split contexts                 |
+| Direct default import `import TvButton from '@todovue/tv-button'` | Single usage or manual registration            |
 
 ---
 ## Props
 All boolean style props have two interchangeable forms: a long form (`isSomething`) and a short alias.
 
-| Prop | Aliases | Type | Default | Description |
-|------|---------|------|---------|-------------|
-| buttonText | — | string | '' | Optional text (alternative to slot). |
-| customStyle | — | object | {} | Inline style overrides (`{ backgroundColor, color }`). |
-| icon | — | string | null | Name of bundled icon. |
-| iconColor | — | string | 'white' | Declared but currently not applied (see Roadmap). |
-| iconPosition | — | 'left' \| 'right' | 'right' | Icon position relative to text. |
-| type | — | 'button' \| 'icon' | 'button' | Variant selector AND passed to native `type` attribute (see note below). |
-| ariaLabel | — | string | '' | Accessibility label (required if no text / icon-only). |
-| iconOnly | — | boolean | false | Renders only the icon (no padding/background). |
-| isOutlined | outlined | boolean | false | Outlined style. |
-| isSmall | small | boolean | false | Small size. |
-| isLarge | large | boolean | false | Large size. |
-| isSuccess | success | boolean | false | Success variant. |
-| isInfo | info | boolean | false | Info variant. |
-| isWarning | warning | boolean | false | Warning variant. |
-| isError | error | boolean | false | Error variant. |
-| isDisabled | disabled | boolean | false | Disables interaction. |
-| isText | text | boolean | false | Text (minimal) style. |
-| isFull | full | boolean | false | Full width. |
-| isRounded | rounded | boolean | false | Rounded corners. |
-| isLoading | loading | boolean | false | Shows spinner & disables. |
-| isCircle | circle | boolean | false | Currently unused (placeholder). |
+| Prop         | Aliases  | Type               | Default  | Description                                                              |
+|--------------|----------|--------------------|----------|--------------------------------------------------------------------------|
+| buttonText   | —        | string             | ''       | Optional text (alternative to slot).                                     |
+| customStyle  | —        | object             | {}       | Inline style overrides (`{ backgroundColor, color }`).                   |
+| icon         | —        | string             | null     | Name of bundled icon.                                                    |
+| iconColor    | —        | string             | 'white'  | Declared but currently not applied (see Roadmap).                        |
+| iconPosition | —        | 'left' \| 'right'  | 'right'  | Icon position relative to text.                                          |
+| type         | —        | 'button' \| 'icon' | 'button' | Variant selector AND passed to native `type` attribute (see note below). |
+| ariaLabel    | —        | string             | ''       | Accessibility label (required if no text / icon-only).                   |
+| iconOnly     | —        | boolean            | false    | Renders only the icon (no padding/background).                           |
+| isOutlined   | outlined | boolean            | false    | Outlined style.                                                          |
+| isSmall      | small    | boolean            | false    | Small size.                                                              |
+| isLarge      | large    | boolean            | false    | Large size.                                                              |
+| isSuccess    | success  | boolean            | false    | Success variant.                                                         |
+| isInfo       | info     | boolean            | false    | Info variant.                                                            |
+| isWarning    | warning  | boolean            | false    | Warning variant.                                                         |
+| isError      | error    | boolean            | false    | Error variant.                                                           |
+| isDisabled   | disabled | boolean            | false    | Disables interaction.                                                    |
+| isText       | text     | boolean            | false    | Text (minimal) style.                                                    |
+| isFull       | full     | boolean            | false    | Full width.                                                              |
+| isRounded    | rounded  | boolean            | false    | Rounded corners.                                                         |
+| isLoading    | loading  | boolean            | false    | Shows spinner & disables.                                                |
+| isCircle     | circle   | boolean            | false    | Currently unused (placeholder).                                          |
 
 > Note: Because `type` is bound to the native `<button type="...">`, using `type="icon"` produces a non-standard button attribute. This does not break rendering but is semantically incorrect in forms. A future release will introduce `variant` and keep `htmlType` separate (see Roadmap).
 
 ---
 ## Events
-| Event name (kebab) | Emits (camel) | Description |
-|--------------------|---------------|-------------|
-| `click-button` | `clickButton` | Custom semantic click event. |
-| `click` | `click` | Native passthrough (also emitted manually). |
+| Event name (kebab) | Emits (camel) | Description                                 |
+|--------------------|---------------|---------------------------------------------|
+| `click-button`     | `clickButton` | Custom semantic click event.                |
+| `click`            | `click`       | Native passthrough (also emitted manually). |
 
 Usage:
 ```vue
@@ -212,19 +203,19 @@ Loading state:
 ---
 ## SSR Notes
 - No direct DOM (`window` / `document`) access in source → safe for SSR.
-- Styles emitted as a separate CSS file (`style.css`) in library build → ideal for Nuxt 3.
+- Styles are now applied automatically when you import the library (no manual CSS import required).
 - SVG icons are bundled via Vite's `import.meta.glob` (works in Vite + Nuxt).
 - Ensure you import `@todovue/tv-button/style.css` in an SSR-compatible entry (plugin or layout).
 
 ---
 ## Roadmap
-| Item | Status |
-|------|--------|
-| Separate `type` into `variant` + `htmlType` | Planned |
-| Implement `iconColor` application | Planned |
-| Implement `isCircle` styling | Planned |
-| Add theming API (CSS vars) | Considering |
-| Add ARIA improvements for loading state | Considering |
+| Item                                        | Status      |
+|---------------------------------------------|-------------|
+| Separate `type` into `variant` + `htmlType` | Planned     |
+| Implement `iconColor` application           | Planned     |
+| Implement `isCircle` styling                | Planned     |
+| Add theming API (CSS vars)                  | Considering |
+| Add ARIA improvements for loading state     | Considering |
 
 ---
 ## Development

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "author": "Cristhian Daza",
   "description": "A customizable button component for TODOvue, supporting multiple variants, sizes, and icon modes.",
   "license": "MIT",
-  "version": "1.0.0",
+  "version": "1.1.1",
   "type": "module",
   "repository": {
     "type": "git",
@@ -29,11 +29,16 @@
     ".": {
       "import": "./dist/tv-button.es.js",
       "require": "./dist/tv-button.cjs.js"
-    }
+    },
+    "./style.css": "./dist/tv-button.css"
   },
   "main": "dist/tv-button.cjs.js",
   "module": "dist/tv-button.es.js",
   "types": "dist/tv-button.d.ts",
+  "style": "dist/tv-button.css",
+  "sideEffects": [
+    "*.css"
+  ],
   "files": [
     "dist",
     "LICENSE",

--- a/src/components/TvButton.vue
+++ b/src/components/TvButton.vue
@@ -75,7 +75,6 @@ const buttonStyles = computed(() => ({
     :aria-label="ariaLabel"
     :class="buttonClasses"
     :disabled="isDisabled || isLoading || disabled || loading"
-    :role="type"
     :style="buttonStyles"
     :type="type"
     @click="handleClick"
@@ -100,9 +99,9 @@ const buttonStyles = computed(() => ({
           <slot v-else></slot>
         </span>
         <span
-            v-if="icon && iconPosition === 'right'"
-            class="tv-icon icon-right"
-            v-html="iconContent"
+          v-if="icon && iconPosition === 'right'"
+          class="tv-icon icon-right"
+          v-html="iconContent"
         />
       </template>
     </span>

--- a/src/demo/Demo.vue
+++ b/src/demo/Demo.vue
@@ -15,7 +15,7 @@ const TvButton = defineAsyncComponent(/* webpackChunkName: "TvButton" */() => im
     npmInstall="@todovue/tv-button"
     sourceLink="https://github.com/TODOvue/tv-button"
     urlClone="https://github.com/TODOvue/tv-button.git"
-    version="1.1.0"
+    version="1.1.1"
   ></tv-demo>
 </template>
 

--- a/src/entry.ts
+++ b/src/entry.ts
@@ -1,3 +1,4 @@
+import './style.css';
 import TvButton from './components/TvButton.vue'
 
 (TvButton as any).install = (app: any) => {

--- a/src/entry.ts
+++ b/src/entry.ts
@@ -1,4 +1,14 @@
 import TvButton from './components/TvButton.vue'
 
+(TvButton as any).install = (app: any) => {
+  app.component('TvButton', TvButton)
+};
+
+export const TvButtonPlugin = {
+  install(app: any) {
+    app.component('TvButton', TvButton)
+  }
+}
+
 export { TvButton }
 export default TvButton

--- a/vite.config.js
+++ b/vite.config.js
@@ -7,7 +7,7 @@ const isDemo = process.env.VITE_BUILD_TARGET === "demo";
 export default defineConfig({
   plugins: [
     vue(),
-    cssInjectedByJsPlugin(),
+    ...(isDemo ? [cssInjectedByJsPlugin()] : []),
     dts({
       insertTypesEntry: true,
       outputDir: "dist",
@@ -21,7 +21,7 @@ export default defineConfig({
     }
     : {
       lib: {
-        entry: "src/components/TvButton.vue",
+        entry: "src/entry.ts",
         name: "TvButton",
         fileName: format => `tv-button.${format}.js`,
         formats: ["es", "cjs"]


### PR DESCRIPTION
## [1.1.1] - 2025-09-05
### Changed
- The library build now uses `src/entry.ts` (exports both the component and the plugin) instead of directly exporting the `.vue` file.
- CSS injection via JS has been removed for the library build (it is only kept for the demo), generating a `tv-button.css` file optimized for SSR/Nuxt.

### Added
- Plugin installation support: `app.use(TvButton)` or `app.use(TvButtonPlugin)`.
- Explicit export of the style file: `import '@todovue/tv-button/style.css'`.
- Documentation for usage in SSR and Nuxt 3 applications.
