### PR TITLE
Fixed export nuxt.js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to `@todovue/tv-button` will be documented in this file.
 
 This project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.2.1] - 2025-11-20
+
+### Fixed
+- Fixed missing export of `nux.js` file in the package.
+- Create `global.d.ts` to declare module for TypeScript users.
+- Create `tsconfig.json` for proper type checking during build.
+
 ## [1.2.0] - 2025-11-20
 
 ### Dependencies
@@ -77,6 +84,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Ready-to-use as a standalone or global Vue component.
 - Scoped styles using SCSS.
 
+[1.2.1]: https://github.com/TODOvue/tv-button/pull/19/files
 [1.2.0]: https://github.com/TODOvue/tv-button/pull/18/files
 [1.1.3]: https://github.com/TODOvue/tv-button/pull/17/files
 [1.1.2]: https://github.com/TODOvue/tv-button/pull/16/files

--- a/global.d.ts
+++ b/global.d.ts
@@ -1,0 +1,11 @@
+declare module '*.vue' {
+  import { DefineComponent } from 'vue';
+  const component: DefineComponent<{}, {}, any>;
+  export default component;
+}
+
+declare module '*.svg';
+declare module '*.png';
+declare module '*.jpg';
+declare module '*.jpeg';
+declare module '*.gif';

--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
   "files": [
     "dist",
     "LICENSE",
-    "README.md"
+    "README.md",
+    "nuxt.js"
   ],
   "engines": {
     "node": ">=20.19.0"

--- a/src/demo/Demo.vue
+++ b/src/demo/Demo.vue
@@ -14,7 +14,7 @@ const TvButton = defineAsyncComponent(/* webpackChunkName: "TvButton" */() => im
     npm-install="@todovue/tv-button"
     source-link="https://github.com/TODOvue/tv-button"
     url-clone="https://github.com/TODOvue/tv-button.git"
-    version="1.2.0"
+    version="1.2.1"
   />
 </template>
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,26 @@
+{
+  "compilerOptions": {
+    "module": "ESNext",
+    "moduleResolution": "node",
+    "target": "ESNext",
+    "lib": ["ESNext", "DOM"],
+    "jsx": "preserve",
+    "isolatedModules": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "outDir": "dist/types"
+  },
+
+  "include": [
+    "global.d.ts",
+    "src/**/*.ts",
+    "src/**/*.vue"
+  ],
+
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
+}


### PR DESCRIPTION
## [1.2.1] - 2025-11-20

### Fixed
- Fixed missing export of `nux.js` file in the package.
- Create `global.d.ts` to declare module for TypeScript users.
- Create `tsconfig.json` for proper type checking during build.